### PR TITLE
ff-494 — Silenced the HTTP/2 error when a news server terminates the connection

### DIFF
--- a/changes/unreleased.md
+++ b/changes/unreleased.md
@@ -9,3 +9,4 @@
 - ff-497 — Silenced the error when a news server disconnects without sending all the data.
 - ff-496 — Better SLL error handling.
 - ff-495 — Silenced the HTTP/2 error when a news server resets a stream.
+- ff-494 — Silenced the HTTP/2 error when a news server terminates the connection.

--- a/ffun/ffun/feeds/entities.py
+++ b/ffun/ffun/feeds/entities.py
@@ -46,6 +46,7 @@ class FeedError(enum.IntEnum):
     network_server_disconnected = 1024
     network_server_closed_connection_too_early = 1025
     network_server_reset_http2_stream = 1026
+    network_server_terminated_connection = 1027
 
     parsing_unknown = 2000
     parsing_base_error = 2001

--- a/ffun/ffun/loader/operations.py
+++ b/ffun/ffun/loader/operations.py
@@ -91,8 +91,17 @@ async def load_content(  # noqa: CFQ001, CCR001, C901 # pylint: disable=R0912, R
             # There are quite a lot of such errors (~1000 in a week)
             # But it seems they are random (feeds with errors loaded successfully later)
             # => we should monitor the situation, maybe it will be fixed in the future HTTPX releases
+            # Also, this error may be caused by our protocol-loop logic.
             log.warning("network_server_reset_http2_stream")
             error_code = FeedError.network_server_reset_http2_stream
+        elif "ConnectionTerminated" in message:
+            # This is HTTP/2 specific error
+            # It appeared after HTTPX was updated, and the support of HTTP/2 was turned on
+            # There are quite a lot of such errors (~100 in a week)
+            # Currently, all such errors are with error_code:0 => we may just reconnect later
+            # Also, it seems they are caused by our protocol-loop logic.
+            log.warning("network_server_terminated_connection")
+            error_code = FeedError.network_server_terminated_connection
         else:
             log.exception("remote_protocol_error_while_loading_feed")
 


### PR DESCRIPTION
…connection