### PR TITLE
ff-553 — Silenced expected `ProtocolError "Invalid input ConnectionInputs.RECV_DATA in state ConnectionState.CLOSED"` in feeds loader

### DIFF
--- a/changes/unreleased.md
+++ b/changes/unreleased.md
@@ -1,3 +1,4 @@
 
 - ff-534 — Silenced expected `httpx.WriteError` in feeds loader.
 - ff-552 — Silenced expected `ProxyError "TUN_ERR: DNS resolution failed"` in feeds loader.
+- ff-553 — Silenced expected `ProtocolError "Invalid input ConnectionInputs.RECV_DATA in state ConnectionState.CLOSED"` in feeds loader.


### PR DESCRIPTION
…puts.RECV_DATA in state ConnectionState.CLOSED"` in feeds loader