### PR TITLE
ff-571 — Closed access to `/realms/dev/account*` endpoints in Caddy dev config.

### DIFF
--- a/changes/unreleased.md
+++ b/changes/unreleased.md
@@ -12,8 +12,8 @@ No changes.
 - ff-576 — Track clicks on authentication-related buttons.
 - ff-565 — Correct properties for session cookies (SPA <-> Gateway).
 - ff-579 — Removed api methods with optional authentication. Not all auth proxies work well with optional auth.
-- ff-584 — Authentication refactored to OAuth2Proxy.
 - ff-581 — Added protection from the `X-*` headers injection into Caddy dev config.
+- ff-571 — Closed access to `/realms/dev/account*` endpoints in Caddy dev config.
 
 TODO:
 

--- a/docker/dev/caddy/Caddyfile
+++ b/docker/dev/caddy/Caddyfile
@@ -111,6 +111,11 @@ feeds.fun.local {
 idp.feeds.fun.local {
   tls internal
 
+  # Simple and effective way to disable Keycloak account console
+  handle_path /realms/dev/account* {
+    respond "Not found" 404
+  }
+
   import idp_proxy
 }
 


### PR DESCRIPTION
…ev config